### PR TITLE
Allow installation with m2e 1.1 and subclipse 1.8

### DIFF
--- a/org.sonatype.m2e.subclipse/META-INF/MANIFEST.MF
+++ b/org.sonatype.m2e.subclipse/META-INF/MANIFEST.MF
@@ -10,11 +10,11 @@ Require-Bundle: org.eclipse.ui,
  org.eclipse.core.resources,
  org.eclipse.team.core,
  org.eclipse.team.ui,
- org.tigris.subversion.subclipse.core;bundle-version="[1.6.0,1.7.0)",
- org.tigris.subversion.subclipse.ui;bundle-version="[1.6.0,1.7.0)",
- org.eclipse.m2e.core;bundle-version="[1.0.0,1.1.0)",
- org.eclipse.m2e.scm;bundle-version="[1.0.0,1.1.0)",
- org.eclipse.m2e.maven.runtime;bundle-version="[1.0.0,1.1.0)"
+ org.tigris.subversion.subclipse.core;bundle-version="[1.6.0,2.0.0)",
+ org.tigris.subversion.subclipse.ui;bundle-version="[1.6.0,2.0.0)",
+ org.eclipse.m2e.core;bundle-version="[1.0.0,1.2.0)",
+ org.eclipse.m2e.scm;bundle-version="[1.0.0,1.2.0)",
+ org.eclipse.m2e.maven.runtime;bundle-version="[1.0.0,1.2.0)"
 Eclipse-LazyStart: true
 Bundle-RequiredExecutionEnvironment: J2SE-1.5
 Export-Package: org.sonatype.m2e.subclipse.internal;x-internal:=true


### PR DESCRIPTION
As the APIs for m2e 1.1 have not changed and the subclipse APIs are
stable in the 1.x stream this is a safe change to perform.

I have verified this with m2e 1.1 ( nightly ) and subclipse 1.8.6 .
